### PR TITLE
Remove the bind all as it binds to all view instead the desired login…

### DIFF
--- a/views/main.py
+++ b/views/main.py
@@ -114,12 +114,6 @@ class LoginView(ttk.Frame):
                                           command=handle_register_view).grid(
             row=3, column=1, pady=20, rowspan=2)
 
-        # ------------ Key bindings ------------ #
-        def handle_login_event(_):
-            handle_login()
-
-        self.bind_all('<Return>', handle_login_event)
-
         self.tkraise()
 
 


### PR DESCRIPTION
- Remove `bind_all` method as it binds to all view / frame rather the login frame.